### PR TITLE
Use -dev not -SNAPSHOT to avoid download-the-internet-over-vpn builds

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,10 @@
+<?xml version="1.0"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.kodewerk.epump</groupId>
   <artifactId>epump</artifactId>
-  <version>1.2-SNAPSHOT</version>
+  <version>1.2-dev</version>
   <packaging>jar</packaging>
   <inceptionYear>2014</inceptionYear>
 


### PR DESCRIPTION
Use -dev instead of -SNAPSHOT to fix download-the-internet-over-vpn builds